### PR TITLE
Flush final read group at EOF in count_transcript_abundance

### DIFF
--- a/TElocal
+++ b/TElocal
@@ -425,7 +425,64 @@ def count_transcript_abundance(filename, geneIdx, teIdx, stranded, te_mode, sort
 
     except StopIteration:
         pass
-        # the last read
+
+    # Flush the final pending read group. The main loop only finalizes a
+    # group on the *next* read-name transition; without this block the
+    # last group in every BAM is silently dropped at StopIteration. This
+    # implements the "# the last read" comment that was previously a
+    # placeholder.
+    if prev_read_name != "":
+        if paired:
+            final_apr = []
+            if len(multi_read1) <= 1 and len(multi_read2) <= 1:
+                uniq_reads += 1
+                r1 = multi_read1[0] if multi_read1 else None
+                r2 = multi_read2[0] if multi_read2 else None
+                if r1 is not None or r2 is not None:
+                    final_apr.append((r1, r2))
+            else:
+                nonunique += 1
+                if te_mode == 'uniq':
+                    empty += 1
+                else:
+                    if len(multi_read2) == 0:
+                        for r in multi_read1:
+                            final_apr.append((r, None))
+                    elif len(multi_read1) == 0:
+                        for r in multi_read2:
+                            final_apr.append((None, r))
+                    elif len(multi_read1) == len(multi_read2):
+                        for idx in range(len(multi_read1)):
+                            final_apr.append((multi_read1[idx], multi_read2[idx]))
+        else:
+            final_apr = alignments_per_read
+            if len(alignments_per_read) == 1:
+                uniq_reads += 1
+            elif len(alignments_per_read) > 1:
+                nonunique += 1
+                if te_mode == 'uniq':
+                    empty += 1
+                    final_apr = []
+
+        if final_apr:
+            try:
+                (annot_gene, annot_TE) = ovp_annotation(references, final_apr, geneIdx, teIdx, stranded)
+                if len(final_apr) > 1:
+                    no_annot_te = parse_annotations_TE(multi_reads, annot_TE, te_counts, te_multi_counts, leftOver_te)
+                    if no_annot_te:
+                        no_annot_gene = parse_annotations_gene(annot_gene, gene_counts, leftOver_gene)
+                        if no_annot_gene:
+                            empty += 1
+                else:
+                    no_annot_gene = parse_annotations_gene(annot_gene, gene_counts, leftOver_gene)
+                    if no_annot_gene:
+                        no_annot_te = parse_annotations_TE(multi_reads, annot_TE, te_counts, te_multi_counts, leftOver_te)
+                        if no_annot_te:
+                            empty += 1
+            except:
+                sys.stderr.write("Error occurred when processing final read group %s in file %s.\n" % (prev_read_name, filename))
+                raise
+
     try:
         # resolve ambiguity
         if len(leftOver_gene) > 0:


### PR DESCRIPTION
## Summary

The counting loop's final pending read group is silently dropped at EOF in every BAM. This change adds the missing flush block to the `StopIteration` path so the last group is counted instead of lost.

## Bug

`TElocal:426-428` (current `master`):

```python
    except StopIteration:
        pass
        # the last read
    try:
        # resolve ambiguity
```

The existing `# the last read` comment acknowledges that the final group still needs to be processed, but the implementation is just `pass`. The main loop in `count_transcript_abundance` only finalizes a read group on the *next* read-name transition (`if cur_read_name == prev_read_name ... else: ...` paths around lines 320 and 370). When `next(samfile)` raises `StopIteration` at EOF, control falls into the `except` and immediately hits the ambiguity-resolution `try:` block — the buffered `multi_read1` / `multi_read2` (paired) or `alignments_per_read` (single-end) for the last read name in the BAM is never passed to `ovp_annotation` / `parse_annotations_*`, and that read group is silently dropped from both gene and TE counts.

The bug affects every BAM that TElocal processes, regardless of `--mode`, `--stranded`, or paired-vs-single. It costs exactly one read group per file — small enough to be invisible in routine QC, large enough to bias counts on small/test datasets.

## Reproduction

Build a tiny name-sorted BAM with three single-end reads where the third is the only one that hits a TE locus:

```python
import pysam
header = {"HD":{"VN":"1.0","SO":"queryname"}, "SQ":[{"SN":"chr1","LN":100000}]}
with pysam.AlignmentFile("sample.bam","wb",header=header) as bf:
    for q, p in [("read_A", 1050), ("read_B", 2050), ("read_Z_last", 3100)]:
        r = pysam.AlignedSegment(bf.header)
        r.query_name = q; r.flag = 0; r.reference_id = 0
        r.reference_start = p; r.mapping_quality = 60
        r.query_sequence = "A"*100; r.cigar = [(0, 100)]
        r.next_reference_id = -1; r.next_reference_start = -1
        bf.write(r)
```

Pair this with a minimal `genes.gtf` (geneA exon at 1000-1500, geneB exon at 2000-2500) and a single-instance `te.locInd` for L1HS at 3000-3500. Run:

```
TElocal -b sample.bam --GTF genes.gtf --TE te.locInd --project demo -i 0
```

**Before this PR** (`demo.cntTable`):
```
gene/TE                  sample.bam
"geneA"                  1
"geneB"                  1
L1HS_dup1:L1HS:L1:LINE   0
```
`Total annotated reads = 2.0` — `read_Z_last` was silently dropped because it was the last group, and the EOF flush was a no-op.

**After this PR**:
```
gene/TE                  sample.bam
"geneA"                  1
"geneB"                  1
L1HS_dup1:L1HS:L1:LINE   1
```
`Total annotated reads = 3.0`.

## Fix

Replace the `except StopIteration: pass / # the last read` placeholder with a flush block that mirrors the in-loop transition logic:

* **Paired-end branch**: build `final_apr` from the buffered `multi_read1` / `multi_read2`, exactly the way the in-loop `else` branch does on a name transition (uniq path when both buffers have ≤1 mate, non-unique cross-product path otherwise, with `te_mode == 'uniq'` short-circuit). Increment `uniq_reads` / `nonunique` / `empty` to match.
* **Single-end branch**: `alignments_per_read` already holds the last group's reads (the in-loop single-end path appends them via `continue`), so just increment counters and use it directly. Apply the `te_mode == 'uniq'` short-circuit if length > 1.
* If `final_apr` is non-empty, run `ovp_annotation(...)` and the same `parse_annotations_TE` / `parse_annotations_gene` pattern as the in-loop case (multi-read TE-first, single-read gene-first).

The flush is gated on `prev_read_name != ""` so it's a no-op for empty BAMs.

## Verification

Locked end-to-end against the synthetic 3-read fixture above (the `read_Z_last` count flips from 0 to 1, total annotated reads goes from 2 to 3). `python -m py_compile TElocal` clean. `git diff --check` clean. No other behavior changes — the in-loop path is untouched.

Verified by porting a manually-adjusted version of this block back to clean upstream `v1.1.2` (this branch). The same fix has been validated end-to-end in our internal patched fork (`jeffgehlhausen/TElocal-mt 1.2.0-mt`) against the same synthetic fixture and a range of larger BAMs.

Happy to rebase, split, or adjust scope if any of this doesn't match the project's preferences.
